### PR TITLE
Fix typo in apt-get command

### DIFF
--- a/ch00.txt
+++ b/ch00.txt
@@ -151,7 +151,7 @@ Plus some others:
 Which we install like this (using the Debian-style apt-get package manager):
 
 ```
-sudo apt-get install -y
+sudo apt-get install -y \
     git-all build-essential libtool \
     pkg-config autotools-dev autoconf automake cmake \
     asciidoc uuid-dev libpcre3-dev valgrind


### PR DESCRIPTION
The line continuation backslash is missing from the first line.
